### PR TITLE
Added polarization tools example

### DIFF
--- a/acs_polarization_tools/acs_polarization_tools.ipynb
+++ b/acs_polarization_tools/acs_polarization_tools.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "| Package Name     | module           | docs          | used for    |\n",
     "|------------------|:-----------------|:-------------:|:------------|\n",
-    "|`acstools`       |`acs_destripe_plus`| <a class=\"divlink\" href=\"https://acstools.readthedocs.io/en/stable/acs_destripe_plus.html\">link</a>| polarization information and methods "
+    "|`acstools`       |`polarization_tools`| <a class=\"divlink\" href=\"https://acstools.readthedocs.io/en/stable/acs_destripe_plus.html\">link</a>| polarization information and methods "
    ]
   },
   {

--- a/acs_polarization_tools/acs_polarization_tools.ipynb
+++ b/acs_polarization_tools/acs_polarization_tools.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>REQUIREMENT:</b> Before proceeding, install or update your <b><a class=\"divlink\" href=\"https://astroconda.readthedocs.io\">AstroConda</a></b> distribution. The code cells below may not work properly with older versions of AstroConda.a\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using ACS Polarization Tools\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "***\n",
+    "\n",
+    "In December 2020, the ACS Team made available a Python module called `polarization_tools` in the `acstools` package to facilitate data analysis of ACS polarization data. This package contains both tables of calibration terms and class methods for polarization calculations.\n",
+    "\n",
+    "Note that this example does not use imaging data (i.e., FITS files). Where necessary, we will indicate values that come from ACS FITS files.\n",
+    "</div>\n",
+    "\n",
+    "### This tutorial will show you how to...\n",
+    "\n",
+    "#### [Retrieve Polarization Calibration Coefficients](#_coeffs) \n",
+    "\n",
+    "* Get the latest calibration coefficients that are used in `acstools`\n",
+    "\n",
+    "#### [Calculate Polarization Properties](#_properties)\n",
+    "\n",
+    "* Use the `acstools.polarization_tools` module to compute:\n",
+    "    * Stokes parameters\n",
+    "    * Fractional polarization\n",
+    "    * Electric field vector position angle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "***\n",
+    "\n",
+    "Here we list the Python packages used in this notebook. Links to the documentation for each module is provided for convenience.\n",
+    "\n",
+    "| Package Name     | module           | docs          | used for    |\n",
+    "|------------------|:-----------------|:-------------:|:------------|\n",
+    "|`acstools`       |`acs_destripe_plus`| <a class=\"divlink\" href=\"https://acstools.readthedocs.io/en/stable/acs_destripe_plus.html\">link</a>| polarization information and methods "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from acstools import polarization_tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Retrieve Polarization Calibration Coefficients<a id=\"_coeffs\"></a>\n",
+    "\n",
+    "***\n",
+    "\n",
+    "The `polarization_tools` module contains all of the necessary calibration terms from the tables in section 5.3 of the ACS Data Handbook (see tables 5.6 and 5.7). These coefficients are stored in YAML files in `acstools` and may be retrieved as `astropy.Table` tables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "polarizer_tables = polarization_tools.PolarizerTables.from_package_data()\n",
+    "\n",
+    "# print the ACS/WFC polarizer efficiencies\n",
+    "polarizer_tables.wfc_efficiency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the average ACS/WFC cross-polarization leak corrections\n",
+    "polarizer_tables.wfc_transmission"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, the tables contain metadata that describe their derivation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the ACS/WFC cross-polarization leak correction metadata\n",
+    "polarizer_tables.wfc_transmission.meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate Polarization Properties<a id=\"_properties\"></a>\n",
+    "\n",
+    "***\n",
+    "\n",
+    "The `acstools.polarization_tools.Polarizer` class contains methods for calculating the polarization properties of a source given ACS photometry as input. The inputs may be either in electrons or electrons/second, as long as all three (for each POL0, POL60, and POL120) are consistently in the same units. In addition, the class can accept either a single float value for each photometric measurement or a `numpy` array. This has the advantage that the class can construct Stokes images from the ACS photometry.\n",
+    "\n",
+    "For this example, we will use photometry measurements of the polarizated calibration star Vela 1-81 (an OB supergiant). The observations were taken using the ACS/WFC detector and by crossing the polarization filters with the F606W filter. The average PA_V3 value from the primary headers of the FITS files is 294.41272 degrees."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Measured photometry from ACS/WFC data\n",
+    "pol0 = 60603.96\n",
+    "pol60 = 62382.70\n",
+    "pol120 = 67898.63\n",
+    "\n",
+    "# PA_V3 angle\n",
+    "pa_v3 = 294.41272\n",
+    "\n",
+    "pol_data = polarization_tools.Polarization(pol0, pol60, pol120, 'F606W', 'WFC', pa_v3)\n",
+    "pol_data.calc_stokes()\n",
+    "pol_data.calc_polarization()\n",
+    "print(f'Stokes I = {pol_data.stokes_i}, Stokes Q = {pol_data.stokes_q}, Stokes U = {pol_data.stokes_u}')\n",
+    "print(f'Fractional polarization = {pol_data.polarization:0.2%}, Position Angle = {pol_data.angle}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that we did not provide any of the calibration coefficients from the Data Handbook or from the [Retrieve Polarization Calibration Coefficients](#_coeffs) section. This is because the `Polarization` class retrieves the values using the spectral filter and detector information. These calibration values may be overwritten manually by setting the appropriate attributes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the efficiency coefficients cross-polarization leak term used\n",
+    "print(f'c0 = {pol_data.c0}, c60 = {pol_data.c60}, c120 = {pol_data.c120}, cross-leak = {pol_data.transmission_correction}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### For more help:\n",
+    "\n",
+    "More details may be found on the [ACS website](http://www.stsci.edu/hst/instrumentation/acs) and in the [ACS Instrument](https://hst-docs.stsci.edu/display/ACSIHB) and [Data Handbooks](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/other-documents/_documents/acs_dhb.pdf).\n",
+    "\n",
+    "Please visit the [HST Help Desk](http://hsthelp.stsci.edu). Through the help desk portal, you can explore the *HST* Knowledge Base and request additional help from experts."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This adds the example for the `acstools.polarization_tools` module so that we can link to an example from the ACS DHB.